### PR TITLE
Version tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ workflows:
       - orb-tools/increment:
           orb-path: src/commit/orb.yml
           orb-ref: commitdev/commit
-          token-variable: "$CIRCLECI_DEV_API_TOKEN"
+          publish-token-variable: "$CIRCLECI_DEV_API_TOKEN"
           segment: patch # Change this for major/minor/patch releases.
           filters:
-            only: master
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ workflows:
   publish:
     jobs:
       - orb-tools/publish:
-          orb-path: src/commit0/orb.yml
-          orb-ref: commitdev/circleci-orbs@dev:${CIRCLE_BRANCH}
+          orb-path: src/commit/orb.yml
+          orb-ref: commitdev/circleci-orbs@dev:0.0.1
           publish-token-variable: "$CIRCLECI_DEV_API_TOKEN"
           validate: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2.1
+orbs:
+  orb-tools: circleci/orb-tools@2.0.0
+
+workflows:
+  publish:
+    jobs:
+      - orb-tools/publish:
+          orb-path: src/commit0/orb.yml
+          orb-ref: commitdev/circleci-orbs@dev:${CIRCLE_BRANCH}
+          publish-token-variable: "$CIRCLECI_DEV_API_TOKEN"
+          validate: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,13 @@ workflows:
     jobs:
       - orb-tools/publish:
           orb-path: src/commit/orb.yml
-          orb-ref: commitdev/commit@dev:0.0.1
+          orb-ref: commitdev/commit@dev:$CIRCLE_BRANCH
           publish-token-variable: "$CIRCLECI_DEV_API_TOKEN"
           validate: true
+      - orb-tools/increment:
+          orb-path: src/commit/orb.yml
+          orb-ref: commitdev/commit
+          token-variable: "$CIRCLECI_DEV_API_TOKEN"
+          segment: patch # Change this for major/minor/patch releases.
+          filters:
+            only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,6 @@ workflows:
     jobs:
       - orb-tools/publish:
           orb-path: src/commit/orb.yml
-          orb-ref: commitdev/circleci-orbs@dev:0.0.1
+          orb-ref: commitdev/commit@dev:0.0.1
           publish-token-variable: "$CIRCLECI_DEV_API_TOKEN"
           validate: true

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # circleci-orbs
+
 Orbs to help make deployment pipelines for CircleCI easier.
+
+## Development
+
+Guide to Orbs: [CircleCI - Creating Orbs](https://circleci.com/docs/2.0/creating-orbs/)
+
+Locally you'll want to run the validate script against your changed before pushing to your branch.
+
+```bash
+circleci orb validate src/commit/orb.yml
+```
+
+Then once you push to a branch, CircleCI will build and publish your dev version of the orb at `commitdev/commit@dev:$CIRCLE_BRANCH`. You can test the orb by changing the version of the orb you're importing in another project to your dev branch.
+
+
+```yaml
+commit: commitdev/commit@dev:my-branch
+```
+
+## Publishing
+
+Our orb will automatically be published when merging to master branch. By default it's a patch version bump, but we can manually change that in the config.yml if we do a larger release.
+
+We use the [CircleCI Orb Tools Orb](https://circleci.com/orbs/registry/orb/circleci/orb-tools) to publish the orb.

--- a/src/commit/orb.yml
+++ b/src/commit/orb.yml
@@ -1,5 +1,7 @@
+# This code is licensed from CircleCI to the user under the MIT license. See
+# https://circleci.com/orbs/registry/licensing for details.
 version: 2.1
- 
+
 commands:
   version-tag: 
     parameters:
@@ -16,7 +18,6 @@ commands:
           'number-only: 152'
         type: enum
         enum: ['number-tag', 'tag-only', 'number-only']
-    example:
     steps:
       - run:
           name: Create Version Tag
@@ -34,6 +35,4 @@ commands:
               exit 1
             fi
 
-            echo """Created version tag: VERSION_TAG=${VERSION_TAG}
-
-This will be available in all steps in this job, but not in other jobs as part of the workflow."""
+            echo "Created version tag: VERSION_TAG=${VERSION_TAG}\n\nThis will be available in all steps in this job, but not in other jobs as part of the workflow."

--- a/src/commit/orb.yml
+++ b/src/commit/orb.yml
@@ -16,6 +16,7 @@ commands:
           'number-only: 152'
         type: enum
         enum: ['number-tag', 'tag-only', 'number-only']
+    example:
     steps:
       - run:
           name: Create Version Tag
@@ -32,3 +33,7 @@ commands:
               echo 'Unsupported format for version-tag.'
               exit 1
             fi
+
+            echo """Created version tag: VERSION_TAG=${VERSION_TAG}
+
+This will be available in all steps in this job, but not in other jobs as part of the workflow."""

--- a/src/commit/orb.yml
+++ b/src/commit/orb.yml
@@ -22,11 +22,11 @@ commands:
           command: |
             echo 'export COMMIT_NUM=$(git rev-list --count $CIRCLE_SHA1)' >> $BASH_ENV
             echo 'export COMMIT_TAG=$(git rev-parse --short $CIRCLE_SHA1)' >> $BASH_ENV
-            if [ "<< parameters.format >>" == "number-tag" ];then
+            if [ "<< parameters.format >>" = "number-tag" ];then
               echo 'export VERSION_TAG="$COMMIT_NUM-$COMMIT_TAG"' >> $BASH_ENV
-            elif [  "<< parameters.format >>" == "tag-only" ];then
+            elif [  "<< parameters.format >>" = "tag-only" ];then
               echo 'export VERSION_TAG="$COMMIT_TAG"' >> $BASH_ENV
-            elif [  "<< parameters.format >>" == "number-only" ];then
+            elif [  "<< parameters.format >>" = "number-only" ];then
               echo 'export VERSION_TAG="$COMMIT_NUM"' >> $BASH_ENV
             else
               echo 'Unsupported format for version-tag.'

--- a/src/commit/orb.yml
+++ b/src/commit/orb.yml
@@ -36,3 +36,5 @@ commands:
             fi
 
             echo "Created version tag: VERSION_TAG=${VERSION_TAG}\n\nThis will be available in all steps in this job, but not in other jobs as part of the workflow."
+description: |
+  Common commands used by Commit in our build pipelines. See this orb's source: https://github.com/commitdev/circleci-orbs

--- a/src/commit/orb.yml
+++ b/src/commit/orb.yml
@@ -25,13 +25,13 @@ commands:
             COMMIT_NUM=$(git rev-list --count $CIRCLE_SHA1)
             COMMIT_TAG=$(git rev-parse --short $CIRCLE_SHA1)
             if [ "<< parameters.format >>" = "number-tag" ];then
-              echo 'export VERSION_TAG="$COMMIT_NUM-$COMMIT_TAG"' >> $BASH_ENV
+              echo "export VERSION_TAG=\"$COMMIT_NUM-$COMMIT_TAG\"" >> $BASH_ENV
             elif [  "<< parameters.format >>" = "tag-only" ];then
-              echo 'export VERSION_TAG="$COMMIT_TAG"' >> $BASH_ENV
+              echo "export VERSION_TAG=\"$COMMIT_TAG\"" >> $BASH_ENV
             elif [  "<< parameters.format >>" = "number-only" ];then
-              echo 'export VERSION_TAG="$COMMIT_NUM"' >> $BASH_ENV
+              echo "export VERSION_TAG=\"$COMMIT_NUM\"" >> $BASH_ENV
             else
-              echo 'Unsupported format for version-tag.'
+              echo "Unsupported format for version-tag."
               exit 1
             fi
 

--- a/src/commit/orb.yml
+++ b/src/commit/orb.yml
@@ -22,8 +22,8 @@ commands:
       - run:
           name: Create Version Tag
           command: |
-            echo 'export COMMIT_NUM=$(git rev-list --count $CIRCLE_SHA1)' >> $BASH_ENV
-            echo 'export COMMIT_TAG=$(git rev-parse --short $CIRCLE_SHA1)' >> $BASH_ENV
+            COMMIT_NUM=$(git rev-list --count $CIRCLE_SHA1)
+            COMMIT_TAG=$(git rev-parse --short $CIRCLE_SHA1)
             if [ "<< parameters.format >>" = "number-tag" ];then
               echo 'export VERSION_TAG="$COMMIT_NUM-$COMMIT_TAG"' >> $BASH_ENV
             elif [  "<< parameters.format >>" = "tag-only" ];then

--- a/src/commit/orb.yml
+++ b/src/commit/orb.yml
@@ -1,0 +1,34 @@
+version: 2.1
+ 
+commands:
+  version-tag: 
+    parameters:
+      format:
+        default: 'number-tag'
+        description: |
+          Create a more human readable version tag for your builds. Place this step after checkout on
+          your job and it will create an environment variable $VERSION_TAG to use in later steps.
+          Often used to tag docker images or create github release.
+
+          Options are ['number-tag', 'tag-only', 'number-only']
+          'number-tag: 152-afed12g'
+          'tag-only: afed12g'
+          'number-only: 152'
+        type: enum
+        enum: ['number-tag', 'tag-only', 'number-only']
+    steps:
+      - run:
+          name: Create Version Tag
+          command: |
+            echo 'export COMMIT_NUM=$(git rev-list --count $CIRCLE_SHA1)' >> $BASH_ENV
+            echo 'export COMMIT_TAG=$(git rev-parse --short $CIRCLE_SHA1)' >> $BASH_ENV
+            if [ "<< parameters.format >>" == "number-tag" ];then
+              echo 'export VERSION_TAG="$COMMIT_NUM-$COMMIT_TAG"' >> $BASH_ENV
+            elif [  "<< parameters.format >>" == "tag-only" ];then
+              echo 'export VERSION_TAG="$COMMIT_TAG"' >> $BASH_ENV
+            elif [  "<< parameters.format >>" == "number-only" ];then
+              echo 'export VERSION_TAG="$COMMIT_NUM"' >> $BASH_ENV
+            else
+              echo 'Unsupported format for version-tag.'
+              exit 1
+            fi


### PR DESCRIPTION
Created an orb that gives you nicely formatted Version tags to use in your build step.

The tag consists of the commit number followed by the short commit hash of a build. Due to this these are sequential on a per branch basis. This allows you to for example compare two master build images that have been deployed using the tag and immediately know which is older / newer of the two.

I provided two other options of just using the number, or just using the tag. But I can remove these if we don't see a real use for them.