### PR TITLE
2 shallow clones same build num

### DIFF
--- a/src/commit/orb.yml
+++ b/src/commit/orb.yml
@@ -33,7 +33,7 @@ commands:
         type: string
     steps:
       - attach_workspace:
-        at: /tmp/workspace
+          at: /tmp/workspace
       - run:
           name: Create Version Tag
           command: |
@@ -57,17 +57,15 @@ commands:
               echo "export VERSION_TAG=\"$CIRCLE_BUILD_NUM-$COMMIT_TAG\"" >> $BASH_ENV
             fi
       - persist_to_workspace:
-            root: << parameters.workspace >>
-            paths:
-              - << parameters.versionfile >>
+          root: << parameters.workspace >>
+          paths:
+            - << parameters.versionfile >>
       - run:
           name: Print Version
           command: |
             echo "Created version tag: VERSION_TAG=${VERSION_TAG}
-
             This will be available in all steps in this job,
             but not in other jobs as part of the workflow. 
-
             To use in other jobs, add the version-tag command to them."
 description: |
   Common commands used by Commit in our build pipelines. See this orb's source: https://github.com/commitdev/circleci-orbs

--- a/src/commit/orb.yml
+++ b/src/commit/orb.yml
@@ -19,7 +19,7 @@ commands:
         type: enum
         enum: ['number-tag', 'tag-only', 'number-only']
       workspace:
-        default: /tmp/workspace/
+        default: /tmp/workspace
         description: |
           Specify a custom workspace for this script to use. If you're using another workspace throughout your
           jobs you can add it here to. This is where we will save the file with the version-tag to access in
@@ -33,7 +33,7 @@ commands:
         type: string
     steps:
       - attach_workspace:
-          at: /tmp/workspace
+          at: << parameters.workspace >>
       - run:
           name: Create Version Tag
           command: |
@@ -43,11 +43,11 @@ commands:
             else
               COMMIT_TAG=$(git rev-parse --short $CIRCLE_SHA1)
               if [ "<< parameters.format >>" = "number-tag" ];then
-                VERSION_TAG=\"$CIRCLE_BUILD_NUM-$COMMIT_TAG\"
+                VERSION_TAG="$CIRCLE_BUILD_NUM-$COMMIT_TAG"
               elif [  "<< parameters.format >>" = "tag-only" ];then
-                VERSION_TAG=\"$COMMIT_TAG\"
+                VERSION_TAG="$COMMIT_TAG"
               elif [  "<< parameters.format >>" = "number-only" ];then
-                VERSION_TAG=\"$CIRCLE_BUILD_NUM\"
+                VERSION_TAG="$CIRCLE_BUILD_NUM"
               else
                 echo "Unsupported format for version-tag."
                 exit 1

--- a/src/commit/orb.yml
+++ b/src/commit/orb.yml
@@ -63,11 +63,11 @@ commands:
       - run:
           name: Print Version
           command: |
-            'echo "Created version tag: VERSION_TAG=${VERSION_TAG}
+            echo "Created version tag: VERSION_TAG=${VERSION_TAG}
 
-This will be available in all steps in this job,
-but not in other jobs as part of the workflow. 
+            This will be available in all steps in this job,
+            but not in other jobs as part of the workflow. 
 
-To use in other jobs, add the version-tag command to them."'
+            To use in other jobs, add the version-tag command to them."
 description: |
   Common commands used by Commit in our build pipelines. See this orb's source: https://github.com/commitdev/circleci-orbs

--- a/src/commit/orb.yml
+++ b/src/commit/orb.yml
@@ -3,7 +3,7 @@
 version: 2.1
 
 commands:
-  version-tag: 
+  version-tag:
     parameters:
       format:
         default: 'number-tag'
@@ -18,23 +18,56 @@ commands:
           'number-only: 152'
         type: enum
         enum: ['number-tag', 'tag-only', 'number-only']
+      workspace:
+        default: /tmp/workspace/
+        description: |
+          Specify a custom workspace for this script to use. If you're using another workspace throughout your
+          jobs you can add it here to. This is where we will save the file with the version-tag to access in
+          other jobs in your workflow.
+        type: string
+      versionfile:
+        default: version.txt
+        description: |
+          Plain-text file in which the version-tag is stored. To access this in other steps, attach the workspace
+          and cat the contents of the file where you need it. E.g. export VERSION_TAG=$(cat version.txt)
+        type: string
     steps:
+      - attach_workspace:
+        at: /tmp/workspace
       - run:
           name: Create Version Tag
           command: |
-            COMMIT_NUM=$(git rev-list --count $CIRCLE_SHA1)
-            COMMIT_TAG=$(git rev-parse --short $CIRCLE_SHA1)
-            if [ "<< parameters.format >>" = "number-tag" ];then
-              echo "export VERSION_TAG=\"$COMMIT_NUM-$COMMIT_TAG\"" >> $BASH_ENV
-            elif [  "<< parameters.format >>" = "tag-only" ];then
-              echo "export VERSION_TAG=\"$COMMIT_TAG\"" >> $BASH_ENV
-            elif [  "<< parameters.format >>" = "number-only" ];then
-              echo "export VERSION_TAG=\"$COMMIT_NUM\"" >> $BASH_ENV
+            if [ -f << parameters.workspace >>/<< parameters.versionfile >> ]; then
+              echo "<< parameters.versionfile >> already present in your workspace, setting enviroment variable."
+              echo "export VERSION_TAG=$(cat << parameters.workspace >>/<< parameters.versionfile >>)" >> $BASH_ENV
             else
-              echo "Unsupported format for version-tag."
-              exit 1
+              COMMIT_TAG=$(git rev-parse --short $CIRCLE_SHA1)
+              if [ "<< parameters.format >>" = "number-tag" ];then
+                VERSION_TAG=\"$CIRCLE_BUILD_NUM-$COMMIT_TAG\"
+              elif [  "<< parameters.format >>" = "tag-only" ];then
+                VERSION_TAG=\"$COMMIT_TAG\"
+              elif [  "<< parameters.format >>" = "number-only" ];then
+                VERSION_TAG=\"$CIRCLE_BUILD_NUM\"
+              else
+                echo "Unsupported format for version-tag."
+                exit 1
+              fi
+              echo "Saving version-tag to << parameters.workspace >>/<< parameters.versionfile >>"
+              echo "$VERSION_TAG" >> << parameters.workspace >>/<< parameters.versionfile >>
+              echo "export VERSION_TAG=\"$CIRCLE_BUILD_NUM-$COMMIT_TAG\"" >> $BASH_ENV
             fi
+      - persist_to_workspace:
+            root: << parameters.workspace >>
+            paths:
+              - << parameters.versionfile >>
+      - run:
+          name: Print Version
+          command: |
+            'echo "Created version tag: VERSION_TAG=${VERSION_TAG}
 
-            echo "Created version tag: VERSION_TAG=${VERSION_TAG}\n\nThis will be available in all steps in this job, but not in other jobs as part of the workflow."
+This will be available in all steps in this job,
+but not in other jobs as part of the workflow. 
+
+To use in other jobs, add the version-tag command to them."'
 description: |
   Common commands used by Commit in our build pipelines. See this orb's source: https://github.com/commitdev/circleci-orbs


### PR DESCRIPTION
So it turns out, using the Commit Number (number of commits on the current branch) only works if you do a full clone of the repo at every point in which you are wanting to use the number.

To avoid this, and use a much simpler way of getting ordered, short, relevant build tags, I've switched it to grab the CIRCLE_BUILD_NUM instead. This number is NOT sequential, but it is always increasing and will give us the order in which builds are being created by CircleCI.

This number can also be used to track a build back to it's job on CircleCI provided you know which branch it was created on, so it has some relevance to us.

Research:
- You cannot get the commit number via the Github API with just the commit hash in a speedy enough manner
- You cannot use the CircleCI workflow ID because it's random (UUIDv4)
- You can get the latest image pushed and find the most recent tag, then bump by 1. But it's highly susceptible to race conditions, and takes considerable time on ECR
- I looked into using a timestamp, but it was always longer than most of the build numbers, and while meaningful and sortable, this information is available in other ways (image meta-data, build job run time, etc)
- There was a tangent in which I looked into using a base 36 version of a timestamp to make it shorter but I decided it's a bit whacky to be useful to anyone